### PR TITLE
Add docker_convoy_bindir variable for destination directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 # defaults vars file for current role
 docker_convoy_version: '0.5.0'
+docker_convoy_bindir: '/usr/local/bin'
 # vim:ft=ansible:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Install last version
   file:
     src: "/opt/convoy-v{{ docker_convoy_version }}/convoy/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
+    dest: "{{ docker_convoy_bindir }}/{{ item }}"
     state: link
     owner: root
     group: root


### PR DESCRIPTION

since I want to install convoy on a coreos, I can't use `/usr/local/bin` . I've added a variable to make it
configurable.